### PR TITLE
Add `publishConfig` and `lavamoat` fields to `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   },
   "devDependencies": {
     "@lavamoat/allow-scripts": "^2.0.3",
+    "@lavamoat/preinstall-always-fail": "^1.0.0",
     "@metamask/auto-changelog": "^3.1.0",
     "@metamask/eslint-config": "^11.0.1",
     "@metamask/eslint-config-jest": "^11.0.0",
@@ -62,5 +63,14 @@
   "packageManager": "yarn@3.5.0",
   "engines": {
     "node": ">=16.0.0"
+  },
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
+  },
+  "lavamoat": {
+    "allowScripts": {
+      "@lavamoat/preinstall-always-fail": false
+    }
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1214,6 +1214,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@lavamoat/preinstall-always-fail@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "@lavamoat/preinstall-always-fail@npm:1.0.0"
+  checksum: 93af02b34c8a7d99296025fd2052272f26310b38998c07b39f698ba395a5543b450dea41d3a26005c83a634738e6f7de01a7cea0eb5552cfe83abe619c3e7b31
+  languageName: node
+  linkType: hard
+
 "@metamask/auto-changelog@npm:^3.1.0":
   version: 3.1.0
   resolution: "@metamask/auto-changelog@npm:3.1.0"
@@ -1282,6 +1289,7 @@ __metadata:
   resolution: "@metamask/template-sync@workspace:."
   dependencies:
     "@lavamoat/allow-scripts": ^2.0.3
+    "@lavamoat/preinstall-always-fail": ^1.0.0
     "@metamask/auto-changelog": ^3.1.0
     "@metamask/eslint-config": ^11.0.1
     "@metamask/eslint-config-jest": ^11.0.0


### PR DESCRIPTION
## Description

This pull request adds two missing fields, `publishConfig` and `lavamoat` to the `package.json`. The `publishConfig` is required to deploy this as a public package under the `@metamask/` NPM organisation.

In order to generate the LavaMoat section, `@lavamoat/preinstall-always-fail` was added.

## Changes

1. Add `publishConfig` field to `package.json`.
2. Add `lavamoat` field to `package.json`.