### PR TITLE
Run `git add .` after processing

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -78,6 +78,14 @@ export async function main() {
         await checkLocalFiles(spinner);
       },
     },
+    {
+      title: 'Adding files to Git.',
+      task: async () => {
+        await execa('git', ['add', '.'], {
+          cwd: process.cwd(),
+        });
+      },
+    },
   ];
 
   for (const { title, task } of tasks) {


### PR DESCRIPTION
## Description

After processing files, we now run `git add .` to stage all changes. By running `git add .` after processing, we ensure 
that we stage all files that have been created, modified or deleted during the processing.

## Changes

1. Add a step to run `git add .` after processing.