### PR TITLE
Fix repository configuration in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,10 @@
   "name": "@metamask/template-sync",
   "version": "0.0.0",
   "description": "Synchronise a Git repository with the MetaMask module template repository.",
-  "repository": "https://github.com/MetaMask/template-sync.git",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/MetaMask/template-sync.git"
+  },
   "license": "MIT",
   "author": "Maarten Zuidhoorn <maarten@zuidhoorn.com>",
   "main": "dist/index.js",


### PR DESCRIPTION
## Description

This pull request fixes an issue in the `package.json` file where the `repository` field was not set up correctly.

## Changes

1. Change `repository` to an object containing a `type` and `url`