### PR TITLE
Add files array to package.json and update lint:dependencies script

### DIFF
--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -8,7 +8,7 @@ on:
         default: 'main'
         required: true
       release-type:
-        description: 'A SemVer version diff, i.e. major, minor, patch, prerelease etc. Mutually exclusive with "release-version".'
+        description: 'A SemVer version diff, i.e. major, minor, or patch. Mutually exclusive with "release-version".'
         required: false
       release-version:
         description: 'A specific version to bump to. Mutually exclusive with "release-type".'

--- a/package.json
+++ b/package.json
@@ -10,13 +10,16 @@
   "author": "Maarten Zuidhoorn <maarten@zuidhoorn.com>",
   "main": "dist/index.js",
   "bin": "dist/index.js",
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "build": "tsc --project tsconfig.build.json",
     "build:clean": "rimraf dist && yarn build",
     "build:docs": "typedoc",
-    "lint": "yarn lint:eslint && yarn lint:misc --check && yarn lint:dependencies && yarn lint:changelog",
+    "lint": "yarn lint:eslint && yarn lint:misc --check && yarn lint:dependencies --check && yarn lint:changelog",
     "lint:changelog": "auto-changelog validate",
-    "lint:dependencies": "depcheck",
+    "lint:dependencies": "depcheck && yarn dedupe",
     "lint:eslint": "eslint . --cache --ext js,ts",
     "lint:fix": "yarn lint:eslint --fix && yarn lint:misc --write && yarn lint:dependencies && yarn lint:changelog",
     "lint:misc": "prettier '**/*.json' '**/*.md' '!CHANGELOG.md' '**/*.yml' '!.yarnrc.yml' --ignore-path .gitignore --no-error-on-unmatched-pattern",


### PR DESCRIPTION
## Description

This pull request adds the `files` array to `package.json` in order to include files inside the `dist` folder when the
package is published to the npm registry. 

Additionally, the `lint:dependencies` script has been updated to run `yarn dedupe`.

## Changes

1. Add `files` array to `package.json`.
2. Update the `lint:dependencies` script to run `depcheck` and `yarn dedupe`.
   - This was achieved by running `yarn ts-node src`. 😄